### PR TITLE
Fun expectation support

### DIFF
--- a/src/hoax_expect.erl
+++ b/src/hoax_expect.erl
@@ -23,6 +23,8 @@ parse(Mod,[]) ->
 parse(Mod,Expects) ->
     [expectation(Mod, Ex) || Ex <- Expects].
 
+expectation(Mod, {FunctionName, Lambda}) when is_function(Lambda) ->
+    expectation(Mod, FunctionName, hoax_fun:create_wildcard_for_args(Lambda), {return_fun_result, Lambda}, undefined);
 expectation(Mod, {Function, Args}) when is_atom(Mod), is_list(Args) ->
     expectation(Mod, Function, Args, default, undefined);
 expectation(Mod, {Function, Args, Count}) when is_atom(Mod),

--- a/src/hoax_fun.erl
+++ b/src/hoax_fun.erl
@@ -1,0 +1,21 @@
+-module(hoax_fun).
+
+-export([
+         find_name_in_module/2,
+         create_wildcard_for_args/1
+        ]).
+
+find_name_in_module(Module, Fun) ->
+    FunProps = erlang:fun_info(Fun),
+    case lists:keyfind(module, 1, FunProps) of
+        {module, Module} ->
+            {name, FunName} = lists:keyfind(name, 1, FunProps),
+            FunName;
+        _AnotherModule ->
+            not_exported
+    end.
+
+create_wildcard_for_args(Fun) when is_function(Fun) ->
+    FunPL = erlang:fun_info(Fun),
+    Arity = proplists:get_value(arity, FunPL),
+    ['_' || _Val <- lists:seq(1, Arity)].

--- a/src/hoax_invocation.erl
+++ b/src/hoax_invocation.erl
@@ -15,7 +15,7 @@ handle(M, F, Args) ->
                     erlang:error({too_many_invocations, X+1, hoax_fmt:fmt({M, F, ExpectedArgs})});
                 #expectation{action = Action} = Record ->
                     hoax_tab:increment_counter(Record),
-                    perform(Action)
+                    perform(Action, Args)
             end
     end.
 
@@ -30,9 +30,11 @@ keyfind(ActualArgs, [ Expectation = #expectation{args = ExpectedArgs} | Rest ]) 
 keyfind(_, []) ->
     false.
 
-perform(default)         -> '$_hoax_default_return_$';
-perform({return, Value}) -> Value;
-perform({Error, Reason}) -> erlang:Error(Reason).
+perform(default, _)         -> '$_hoax_default_return_$';
+perform({return_fun_result, Fun}, Args) ->
+    erlang:apply(Fun, Args);
+perform({return, Value}, _) -> Value;
+perform({Error, Reason}, _) -> erlang:Error(Reason).
 
 replace_wildcards(ActualArgs, ExpectedArgs) ->
     lists:zipwith(fun replace_wildcard/2, ActualArgs, ExpectedArgs).

--- a/src/hoax_macro.erl
+++ b/src/hoax_macro.erl
@@ -4,15 +4,9 @@
          test_list/3
         ]).
 
--ifdef(TEST).
--export([
-         find_fun_name/2
-        ]).
--endif.
-
 test_list(Module, Setup, Teardown) when is_function(Setup) andalso is_function(Teardown)->
-    SetupName = find_fun_name(Module, Setup),
-    TeardownName = find_fun_name(Module, Teardown),
+    SetupName = hoax_fun:find_name_in_module(Module, Setup),
+    TeardownName = hoax_fun:find_name_in_module(Module, Teardown),
     [ {Module, F} ||
         {F, 0} <- Module:module_info(exports),
         F =/= hoax_fixture_test_,
@@ -21,13 +15,3 @@ test_list(Module, Setup, Teardown) when is_function(Setup) andalso is_function(T
         F =/= SetupName,
         F =/= TeardownName
     ].
-
-find_fun_name(Module, Fun) ->
-    FunProps = erlang:fun_info(Fun),
-    case lists:keyfind(module, 1, FunProps) of
-        {module, Module} ->
-            {name, FunName} = lists:keyfind(name, 1, FunProps),
-            FunName;
-        _AnotherModule ->
-            not_exported
-    end.

--- a/test/hoax_expect_test.erl
+++ b/test/hoax_expect_test.erl
@@ -94,6 +94,14 @@ parse_should_return_empty_list_when_expectation_is_sentinel_value_test() ->
         ets:delete(hoax)
     end.
 
+parse_should_allow_fun_in_lieu_of_args_test() ->
+    Fun = fun(Arg1, Arg2,Arg3) -> {Arg1,Arg2,Arg3} end,
+    Expectation = {function_0, Fun},
+    [Result] = hoax_expect:parse(test_mod, [Expectation]),
+    ExpectedOutput = #expectation{key={test_mod, function_0, 3}, args=['_', '_', '_'],
+                                  action={return_fun_result, Fun}},
+    ?assertEqual(ExpectedOutput, Result).
+
 parse_should_throw_when_bad_expectation_syntax_test_() ->
     [ {T, ?_assertError({bad_expectation_syntax, E},
                         hoax_expect:parse(test_mod, [E]))}

--- a/test/hoax_fun_test.erl
+++ b/test/hoax_fun_test.erl
@@ -1,0 +1,24 @@
+-module(hoax_fun_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+should_find_name_in_module_test_() ->
+    [
+     ?_assertEqual(setup, hoax_fun:find_name_in_module(?MODULE, fun hoax_fun_test:setup/0 )),
+     ?_assertEqual(teardown, hoax_fun:find_name_in_module(?MODULE, fun hoax_fun_test:teardown/1 ))
+    ].
+
+setup() ->
+    ok.
+
+teardown(_) ->
+    ok.
+
+
+should_find_arg_count_for_fun_test() ->
+    TestFun = fun(_Arg1, _Arg2, _Arg3) ->
+                      ok
+              end,
+    ?assertEqual(['_', '_', '_'], hoax_fun:create_wildcard_for_args(TestFun)).

--- a/test/hoax_invocation_test.erl
+++ b/test/hoax_invocation_test.erl
@@ -30,6 +30,16 @@ should_return_expected_value_when_args_match() ->
 
     ?assertEqual(a_result, Result).
 
+should_return_fun_result_when_expected_args_for_fun() ->
+    Fun = fun(Val1, Val2) -> {Val1, Val2} end,
+
+    hoax_tab:insert( ?EXPECT(f,['_','_'], {return_fun_result,Fun}) ),
+
+    Result = hoax_invocation:handle(m, f, [1, 2]),
+
+    ?assertEqual({1,2}, Result).
+
+
 should_return_expected_value_when_expected_args_include_wildcard_match() ->
     hoax_tab:insert( ?EXPECT(f,[1,'_'], {return,a_result}) ),
 

--- a/test/hoax_macro_test.erl
+++ b/test/hoax_macro_test.erl
@@ -7,18 +7,13 @@
 hoax_macro_test_list_test() ->
     Result = hoax_macro:test_list(?MODULE, fun hoax_macro_test:setup/0, (fun hoax_macro_test:teardown/1) ),
     ?assertEqual([
-                  {?MODULE, hoax_macro_test_list_test},
-                  {?MODULE, hoax_macro_find_fun_name_test_}
+                  {?MODULE, hoax_macro_test_list_test}
                  ], Result).
 
-hoax_macro_find_fun_name_test_() ->
-    [
-     ?_assertEqual(setup, hoax_macro:find_fun_name(?MODULE, fun hoax_macro_test:setup/0 )),
-     ?_assertEqual(teardown, hoax_macro:find_fun_name(?MODULE, fun hoax_macro_test:teardown/1 ))
-    ].
 
 setup() ->
     ok.
 
 teardown(_) ->
     ok.
+

--- a/test/hoax_test.erl
+++ b/test/hoax_test.erl
@@ -42,3 +42,14 @@ should_be_able_to_mock_sticky_modules_test() ->
     after
         code:unstick_mod(hoax_test_module)
     end.
+
+full_stack_fun_expectation_test() ->
+    hoax:start(),
+    Expected = 1,
+    mock(hoax_test_module, ?expect(function_two, fun(Val) ->
+                                  ?assertEqual(Expected, Val),
+                                  local_return
+                                  end)),
+
+    ?assertEqual(local_return, hoax_test_module:function_two(Expected)),
+    hoax:stop().


### PR DESCRIPTION
This patch adds support for expectations of the form ?expect(FunName, Lambda)
where Lambda is an arbitrary fun with the correct arity.  This allows for
more complicated interactions with hoax where a simple match on args is not
sufficient.
