### PR TITLE
Add generators for parameterized fixtures

### DIFF
--- a/src/hoax.erl
+++ b/src/hoax.erl
@@ -3,7 +3,7 @@
 -export([start/0, stop/0]).
 -export([mock/2, stub/3]).
 -export([fixture/1, fixture/2, fixture/3, fixture/4, test/1]).
-%% -export([parameterized_fixture/1, parameterized_fixture/2, parameterized_fixture/3, parameterized_fixture/4]).
+-export([parameterized_fixture/1, parameterized_fixture/2, parameterized_fixture/3, parameterized_fixture/4]).
 -ignore_xref([mock/2, stub/3]).
 
 %% ===================================================================
@@ -56,6 +56,29 @@ fixture(Module, Prefix, Setup, Teardown) when is_atom(Setup), is_atom(Teardown) 
             prefix_test_selector(Prefix, F)
     end,
     fixture_tuple(Module, 0, fun Module:Setup/0, fun Module:Teardown/1, Selector).
+
+parameterized_fixture(Module) ->
+    fixture_tuple(Module, 1, fun no_op/0, fun no_op/1, fun default_test_selector/1).
+
+parameterized_fixture(Module, Prefix) ->
+    Selector = fun(F) ->
+        default_test_selector(F) andalso prefix_test_selector(Prefix, F)
+    end,
+
+    fixture_tuple(Module, 1, fun no_op/0, fun no_op/1, Selector).
+
+parameterized_fixture(Module, Setup, Teardown) when is_atom(Setup), is_atom(Teardown) ->
+    Selector = fun(F) ->
+        default_test_selector(F) andalso setup_teardown_test_selector(F, Setup, Teardown)
+    end,
+    fixture_tuple(Module, 1, fun Module:Setup/0, fun Module:Teardown/1, Selector).
+
+parameterized_fixture(Module, Prefix, Setup, Teardown) when is_atom(Setup), is_atom(Teardown) ->
+    Selector = fun(F) ->
+        default_test_selector(F) andalso setup_teardown_test_selector(F, Setup, Teardown) andalso
+            prefix_test_selector(Prefix, F)
+    end,
+    fixture_tuple(Module, 1, fun Module:Setup/0, fun Module:Teardown/1, Selector).
 
 test(Func) when is_function(Func, 0) ->
     try

--- a/src/hoax.erl
+++ b/src/hoax.erl
@@ -35,7 +35,7 @@ stub(Behaviour, ModuleName, Expectations) ->
 
 fixture(Module) ->
     {foreach, fun start/0, fun (_) -> stop() end, [
-        {Module, F} || {F, 0} <- Module:module_info(exports),
+        fun Module:F/0 || {F, 0} <- Module:module_info(exports),
         default_test_selector(F) == true
     ]}.
 
@@ -43,7 +43,7 @@ fixture(Module, Prefix) when is_atom(Prefix) ->
     fixture(Module, atom_to_list(Prefix));
 fixture(Module, Prefix) when is_list(Prefix) ->
     {foreach, fun start/0, fun (_) -> stop() end, [
-        {Module, F} || {F, 0} <- Module:module_info(exports),
+        fun Module:F/0 || {F, 0} <- Module:module_info(exports),
             default_test_selector(F) == true,
             prefix_test_selector(Prefix, F)
     ]}.
@@ -52,7 +52,7 @@ fixture(Module, Setup, Teardown) when is_atom(Setup), is_atom(Teardown) ->
     {foreach,
         fun () -> start(), Module:Setup() end,
         fun (X) -> Module:Teardown(X), stop() end, [
-        {Module, F} || {F, 0} <- Module:module_info(exports),
+        fun Module:F/0 || {F, 0} <- Module:module_info(exports),
             default_test_selector(F) == true,
             setup_teardown_test_selector(F, Setup, Teardown)
     ]}.
@@ -63,7 +63,7 @@ fixture(Module, Prefix, Setup, Teardown) when is_list(Prefix), is_atom(Setup), i
     {foreach,
         fun () -> start(), Module:Setup() end,
         fun (X) -> Module:Teardown(X), stop() end, [
-        {Module, F} || {F, 0} <- Module:module_info(exports),
+        fun Module:F/0 || {F, 0} <- Module:module_info(exports),
             default_test_selector(F) == true,
             setup_teardown_test_selector(F, Setup, Teardown),
             prefix_test_selector(Prefix, F)

--- a/test/hoax_tests.erl
+++ b/test/hoax_tests.erl
@@ -139,3 +139,95 @@ fixture_with_string_prefix_with_setup_and_teardown_calls_setup_and_teardown_test
 
     ?assertEqual(true, erlang:get(prefix2_setup_called)),
     ?assertEqual({true, some_argument}, erlang:get(prefix2_teardown_called)).
+
+parameterized_fixture_for_entire_module_without_setup_and_teardown_test() ->
+    ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/1 || F <- [
+        parameterized_test_function1, parameterized_test_function2,
+        prefix1_parameterized_test_function_1, prefix1_parameterized_test_function_2, prefix1_teardown,
+        prefix2_parameterized_test_function_1, prefix2_parameterized_test_function_2, prefix2_teardown,
+        teardown
+    ]],
+
+    {foreach, _, _, [{with, Tests}]} = hoax:parameterized_fixture(?EXAMPLE_MODULE),
+
+    ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
+
+parameterized_fixture_for_entire_module_with_setup_and_teardown_calls_setup_and_teardown_test() ->
+    {foreach, Setup, Teardown, _} = hoax:parameterized_fixture(?EXAMPLE_MODULE, setup, teardown),
+
+    erlang:put(setup_called, undefined),
+    erlang:put(teardown_called, undefined),
+    Setup(),
+    Teardown(some_argument),
+
+    ?assertEqual(true, erlang:get(setup_called)),
+    ?assertEqual({true, some_argument}, erlang:get(teardown_called)).
+
+parameterized_fixture_for_entire_module_with_setup_and_teardown_omits_setup_and_teardown_test() ->
+    ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/1 || F <- [
+        parameterized_test_function1, parameterized_test_function2,
+        prefix1_parameterized_test_function_1, prefix1_parameterized_test_function_2, prefix1_teardown,
+        prefix2_parameterized_test_function_1, prefix2_parameterized_test_function_2, prefix2_teardown
+    ]],
+
+    {foreach, _, _, [{with, Tests}]} = hoax:parameterized_fixture(?EXAMPLE_MODULE, setup, teardown),
+
+    ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
+
+parameterized_fixture_with_atom_prefix_without_setup_and_teardown_selects_functions_by_prefix_test() ->
+    ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/1 || F <- [
+        prefix1_parameterized_test_function_1, prefix1_parameterized_test_function_2, prefix1_teardown
+    ]],
+
+    {foreach, _, _, [{with, Tests}]} = hoax:parameterized_fixture(?EXAMPLE_MODULE, prefix1),
+
+    ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
+
+parameterized_fixture_with_string_prefix_without_setup_and_teardown_selects_functions_by_prefix_test() ->
+    ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/1 || F <- [
+        prefix2_parameterized_test_function_1, prefix2_parameterized_test_function_2, prefix2_teardown
+    ]],
+
+    {foreach, _, _, [{with, Tests}]} = hoax:parameterized_fixture(?EXAMPLE_MODULE, "prefix2"),
+
+    ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
+
+parameterized_fixture_with_atom_prefix_with_setup_and_teardown_selects_functions_by_prefix_omitting_setup_and_teardown_test() ->
+    ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/1 || F <- [
+        prefix1_parameterized_test_function_1, prefix1_parameterized_test_function_2
+    ]],
+
+    {foreach, _, _, [{with, Tests}]} = hoax:parameterized_fixture(?EXAMPLE_MODULE, prefix1, prefix1_setup, prefix1_teardown),
+
+    ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
+
+parameterized_fixture_with_string_prefix_with_setup_and_teardown_selects_functions_by_prefix_omitting_setup_and_teardown_test() ->
+    ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/1 || F <- [
+        prefix2_parameterized_test_function_1, prefix2_parameterized_test_function_2
+    ]],
+
+    {foreach, _, _, [{with, Tests}]} = hoax:parameterized_fixture(?EXAMPLE_MODULE, "prefix2", prefix2_setup, prefix2_teardown),
+
+    ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
+
+parameterized_fixture_with_atom_prefix_with_setup_and_teardown_calls_setup_and_teardown_test() ->
+    {foreach, Setup, Teardown, _} = hoax:parameterized_fixture(?EXAMPLE_MODULE, prefix1, prefix1_setup, prefix1_teardown),
+
+    erlang:put(prefix1_setup_called, undefined),
+    erlang:put(prefix1_teardown_called, undefined),
+    Setup(),
+    Teardown(some_argument),
+
+    ?assertEqual(true, erlang:get(prefix1_setup_called)),
+    ?assertEqual({true, some_argument}, erlang:get(prefix1_teardown_called)).
+
+parameterized_fixture_with_string_prefix_with_setup_and_teardown_calls_setup_and_teardown_test() ->
+    {foreach, Setup, Teardown, _} = hoax:parameterized_fixture(?EXAMPLE_MODULE, "prefix2", prefix2_setup, prefix2_teardown),
+
+    erlang:put(prefix2_setup_called, undefined),
+    erlang:put(prefix2_teardown_called, undefined),
+    Setup(),
+    Teardown(some_argument),
+
+    ?assertEqual(true, erlang:get(prefix2_setup_called)),
+    ?assertEqual({true, some_argument}, erlang:get(prefix2_teardown_called)).

--- a/test/hoax_tests.erl
+++ b/test/hoax_tests.erl
@@ -50,40 +50,40 @@ full_stack_fun_expectation_test() ->
 -define(EXAMPLE_MODULE, module_for_testing_fixtures).
 
 fixture_for_entire_module_without_setup_and_teardown_test() ->
-    ExpectedSortedFunctions = [
+    ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
         prefix1_setup, prefix1_test_function_1, prefix1_test_function_2,
         prefix2_setup, prefix2_test_function_1, prefix2_test_function_2,
         setup, test_function1, test_function2
-    ],
+    ]],
 
     {foreach, _, _, Tests} = hoax:fixture(?EXAMPLE_MODULE),
 
-    ?assertEqual(ExpectedSortedFunctions, lists:sort([F || {_, F} <- Tests])).
+    ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
 
 fixture_for_entire_module_with_setup_and_teardown_test() ->
-    ExpectedSortedFunctions = [
+    ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
         prefix1_setup, prefix1_test_function_1, prefix1_test_function_2,
         prefix2_setup, prefix2_test_function_1, prefix2_test_function_2,
         test_function1, test_function2
-    ],
+    ]],
 
     {foreach, _, _, Tests} = hoax:fixture(?EXAMPLE_MODULE, setup, teardown),
 
-    ?assertEqual(ExpectedSortedFunctions, lists:sort([F || {_, F} <- Tests])).
+    ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
 
 fixture_for_prefix_without_setup_and_teardown_test() ->
-    ExpectedSortedPrefix1Functions = [
+    ExpectedSortedPrefix1Functions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
         prefix1_setup, prefix1_test_function_1, prefix1_test_function_2
-    ],
-    ExpectedSortedPrefix2Functions = [
+    ]],
+    ExpectedSortedPrefix2Functions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
         prefix2_setup, prefix2_test_function_1, prefix2_test_function_2
-    ],
+    ]],
 
     {foreach, _, _, Prefix1Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix1),
     {foreach, _, _, Prefix2Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix2),
 
-    ?assertEqual(ExpectedSortedPrefix1Functions, lists:sort([F || {_, F} <- Prefix1Tests])),
-    ?assertEqual(ExpectedSortedPrefix2Functions, lists:sort([F || {_, F} <- Prefix2Tests])),
+    ?assertEqual(ExpectedSortedPrefix1Functions, lists:sort(Prefix1Tests)),
+    ?assertEqual(ExpectedSortedPrefix2Functions, lists:sort(Prefix2Tests)),
 
     {foreach, _, _, Prefix1TestsFromString} = hoax:fixture(?EXAMPLE_MODULE, "prefix1"),
     {foreach, _, _, Prefix2TestsFromString} = hoax:fixture(?EXAMPLE_MODULE, "prefix2"),
@@ -92,18 +92,18 @@ fixture_for_prefix_without_setup_and_teardown_test() ->
     ?assertEqual(Prefix2Tests, Prefix2TestsFromString).
 
 fixture_for_prefix_with_setup_and_teardown_test() ->
-    ExpectedSortedPrefix1Functions = [
+    ExpectedSortedPrefix1Functions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
         prefix1_test_function_1, prefix1_test_function_2
-    ],
-    ExpectedSortedPrefix2Functions = [
+    ]],
+    ExpectedSortedPrefix2Functions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
         prefix2_test_function_1, prefix2_test_function_2
-    ],
+    ]],
 
     {foreach, _, _, Prefix1Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix1, prefix1_setup, prefix1_teardown),
     {foreach, _, _, Prefix2Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix2, prefix2_setup, prefix2_teardown),
 
-    ?assertEqual(ExpectedSortedPrefix1Functions, lists:sort([F || {_, F} <- Prefix1Tests])),
-    ?assertEqual(ExpectedSortedPrefix2Functions, lists:sort([F || {_, F} <- Prefix2Tests])),
+    ?assertEqual(ExpectedSortedPrefix1Functions, lists:sort(Prefix1Tests)),
+    ?assertEqual(ExpectedSortedPrefix2Functions, lists:sort(Prefix2Tests)),
 
     {foreach, _, _, Prefix1TestsFromString} = hoax:fixture(?EXAMPLE_MODULE, "prefix1", prefix1_setup, prefix1_teardown),
     {foreach, _, _, Prefix2TestsFromString} = hoax:fixture(?EXAMPLE_MODULE, "prefix2", prefix2_setup, prefix2_teardown),

--- a/test/hoax_tests.erl
+++ b/test/hoax_tests.erl
@@ -7,35 +7,28 @@
 
 stop_should_unload_all_hoaxed_modules_test() ->
     ExpectedResult = hoax_test_module:function_one(1, 2),
-    hoax:start(),
-
-    try
+    hoax:test(fun() ->
         mock(no_such_module, expect_no_interactions),
         mock(hoax_test_module, ?expect(function_one, ?withArgs([1, 2]), ?andReturn(mocked_return_value))),
 
         ?assertEqual(mocked_return_value, hoax_test_module:function_one(1, 2))
-    after
-        hoax:stop()
-    end,
+    end),
 
     Result = hoax_test_module:function_one(1, 2),
     ?assertEqual(ExpectedResult, Result),
 
-    ?assertMatch({error,nofile}, code:ensure_loaded(no_such_module)).
+    ?assertMatch({error, nofile}, code:ensure_loaded(no_such_module)).
 
 should_be_able_to_mock_sticky_modules_test() ->
     ExpectedResult = hoax_test_module:function_one(1, 2),
     code:stick_mod(hoax_test_module),
     try
-        hoax:start(),
-
-        try
+        hoax:test(fun() ->
             mock(hoax_test_module, ?expect(function_one, ?withArgs([1, 2]), ?andReturn(mocked_return_value))),
             ?assertEqual(mocked_return_value, hoax_test_module:function_one(1, 2)),
             ?assert(code:is_sticky(hoax_test_module))
-        after
-            hoax:stop()
-        end,
+        end),
+
         Result = hoax_test_module:function_one(1, 2),
         ?assertEqual(ExpectedResult, Result),
         ?assert(code:is_sticky(hoax_test_module))
@@ -44,15 +37,15 @@ should_be_able_to_mock_sticky_modules_test() ->
     end.
 
 full_stack_fun_expectation_test() ->
-    hoax:start(),
-    Expected = 1,
-    mock(hoax_test_module, ?expect(function_two, fun(Val) ->
-                                  ?assertEqual(Expected, Val),
-                                  local_return
-                                  end)),
+    hoax:test(fun() ->
+        Expected = 1,
+        mock(hoax_test_module, ?expect(function_two, fun(Val) ->
+            ?assertEqual(Expected, Val),
+            local_return
+        end)),
 
-    ?assertEqual(local_return, hoax_test_module:function_two(Expected)),
-    hoax:stop().
+        ?assertEqual(local_return, hoax_test_module:function_two(Expected))
+    end).
 
 -define(EXAMPLE_MODULE, module_for_testing_fixtures).
 
@@ -65,7 +58,7 @@ fixture_for_entire_module_without_setup_and_teardown_test() ->
 
     {foreach, _, _, Tests} = hoax:fixture(?EXAMPLE_MODULE),
 
-    ?assertEqual(ExpectedSortedFunctions, lists:sort([F || {_,F} <- Tests])).
+    ?assertEqual(ExpectedSortedFunctions, lists:sort([F || {_, F} <- Tests])).
 
 fixture_for_entire_module_with_setup_and_teardown_test() ->
     ExpectedSortedFunctions = [
@@ -76,7 +69,7 @@ fixture_for_entire_module_with_setup_and_teardown_test() ->
 
     {foreach, _, _, Tests} = hoax:fixture(?EXAMPLE_MODULE, setup, teardown),
 
-    ?assertEqual(ExpectedSortedFunctions, lists:sort([F || {_,F} <- Tests])).
+    ?assertEqual(ExpectedSortedFunctions, lists:sort([F || {_, F} <- Tests])).
 
 fixture_for_prefix_without_setup_and_teardown_test() ->
     ExpectedSortedPrefix1Functions = [
@@ -89,8 +82,8 @@ fixture_for_prefix_without_setup_and_teardown_test() ->
     {foreach, _, _, Prefix1Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix1),
     {foreach, _, _, Prefix2Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix2),
 
-    ?assertEqual(ExpectedSortedPrefix1Functions, lists:sort([F || {_,F} <- Prefix1Tests])),
-    ?assertEqual(ExpectedSortedPrefix2Functions, lists:sort([F || {_,F} <- Prefix2Tests])),
+    ?assertEqual(ExpectedSortedPrefix1Functions, lists:sort([F || {_, F} <- Prefix1Tests])),
+    ?assertEqual(ExpectedSortedPrefix2Functions, lists:sort([F || {_, F} <- Prefix2Tests])),
 
     {foreach, _, _, Prefix1TestsFromString} = hoax:fixture(?EXAMPLE_MODULE, "prefix1"),
     {foreach, _, _, Prefix2TestsFromString} = hoax:fixture(?EXAMPLE_MODULE, "prefix2"),
@@ -109,8 +102,8 @@ fixture_for_prefix_with_setup_and_teardown_test() ->
     {foreach, _, _, Prefix1Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix1, prefix1_setup, prefix1_teardown),
     {foreach, _, _, Prefix2Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix2, prefix2_setup, prefix2_teardown),
 
-    ?assertEqual(ExpectedSortedPrefix1Functions, lists:sort([F || {_,F} <- Prefix1Tests])),
-    ?assertEqual(ExpectedSortedPrefix2Functions, lists:sort([F || {_,F} <- Prefix2Tests])),
+    ?assertEqual(ExpectedSortedPrefix1Functions, lists:sort([F || {_, F} <- Prefix1Tests])),
+    ?assertEqual(ExpectedSortedPrefix2Functions, lists:sort([F || {_, F} <- Prefix2Tests])),
 
     {foreach, _, _, Prefix1TestsFromString} = hoax:fixture(?EXAMPLE_MODULE, "prefix1", prefix1_setup, prefix1_teardown),
     {foreach, _, _, Prefix2TestsFromString} = hoax:fixture(?EXAMPLE_MODULE, "prefix2", prefix2_setup, prefix2_teardown),

--- a/test/hoax_tests.erl
+++ b/test/hoax_tests.erl
@@ -60,7 +60,18 @@ fixture_for_entire_module_without_setup_and_teardown_test() ->
 
     ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
 
-fixture_for_entire_module_with_setup_and_teardown_test() ->
+fixture_for_entire_module_with_setup_and_teardown_calls_setup_and_teardown_test() ->
+    {foreach, Setup, Teardown, _} = hoax:fixture(?EXAMPLE_MODULE, setup, teardown),
+
+    erlang:put(setup_called, undefined),
+    erlang:put(teardown_called, undefined),
+    Setup(),
+    Teardown(some_argument),
+
+    ?assertEqual(true, erlang:get(setup_called)),
+    ?assertEqual({true, some_argument}, erlang:get(teardown_called)).
+
+fixture_for_entire_module_with_setup_and_teardown_omits_setup_and_teardown_test() ->
     ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
         prefix1_setup, prefix1_test_function_1, prefix1_test_function_2,
         prefix2_setup, prefix2_test_function_1, prefix2_test_function_2,
@@ -71,42 +82,60 @@ fixture_for_entire_module_with_setup_and_teardown_test() ->
 
     ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
 
-fixture_for_prefix_without_setup_and_teardown_test() ->
-    ExpectedSortedPrefix1Functions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
+fixture_with_atom_prefix_without_setup_and_teardown_selects_functions_by_prefix_test() ->
+    ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
         prefix1_setup, prefix1_test_function_1, prefix1_test_function_2
     ]],
-    ExpectedSortedPrefix2Functions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
+
+    {foreach, _, _, Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix1),
+
+    ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
+
+fixture_with_string_prefix_without_setup_and_teardown_selects_functions_by_prefix_test() ->
+    ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
         prefix2_setup, prefix2_test_function_1, prefix2_test_function_2
     ]],
 
-    {foreach, _, _, Prefix1Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix1),
-    {foreach, _, _, Prefix2Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix2),
+    {foreach, _, _, Tests} = hoax:fixture(?EXAMPLE_MODULE, "prefix2"),
 
-    ?assertEqual(ExpectedSortedPrefix1Functions, lists:sort(Prefix1Tests)),
-    ?assertEqual(ExpectedSortedPrefix2Functions, lists:sort(Prefix2Tests)),
+    ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
 
-    {foreach, _, _, Prefix1TestsFromString} = hoax:fixture(?EXAMPLE_MODULE, "prefix1"),
-    {foreach, _, _, Prefix2TestsFromString} = hoax:fixture(?EXAMPLE_MODULE, "prefix2"),
-
-    ?assertEqual(Prefix1Tests, Prefix1TestsFromString),
-    ?assertEqual(Prefix2Tests, Prefix2TestsFromString).
-
-fixture_for_prefix_with_setup_and_teardown_test() ->
-    ExpectedSortedPrefix1Functions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
+fixture_with_atom_prefix_with_setup_and_teardown_selects_functions_by_prefix_omitting_setup_and_teardown_test() ->
+    ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
         prefix1_test_function_1, prefix1_test_function_2
     ]],
-    ExpectedSortedPrefix2Functions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
+
+    {foreach, _, _, Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix1, prefix1_setup, prefix1_teardown),
+
+    ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
+
+fixture_with_string_prefix_with_setup_and_teardown_selects_functions_by_prefix_omitting_setup_and_teardown_test() ->
+    ExpectedSortedFunctions = [ fun ?EXAMPLE_MODULE:F/0 || F <- [
         prefix2_test_function_1, prefix2_test_function_2
     ]],
 
-    {foreach, _, _, Prefix1Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix1, prefix1_setup, prefix1_teardown),
-    {foreach, _, _, Prefix2Tests} = hoax:fixture(?EXAMPLE_MODULE, prefix2, prefix2_setup, prefix2_teardown),
+    {foreach, _, _, Tests} = hoax:fixture(?EXAMPLE_MODULE, "prefix2", prefix2_setup, prefix2_teardown),
 
-    ?assertEqual(ExpectedSortedPrefix1Functions, lists:sort(Prefix1Tests)),
-    ?assertEqual(ExpectedSortedPrefix2Functions, lists:sort(Prefix2Tests)),
+    ?assertEqual(ExpectedSortedFunctions, lists:sort(Tests)).
 
-    {foreach, _, _, Prefix1TestsFromString} = hoax:fixture(?EXAMPLE_MODULE, "prefix1", prefix1_setup, prefix1_teardown),
-    {foreach, _, _, Prefix2TestsFromString} = hoax:fixture(?EXAMPLE_MODULE, "prefix2", prefix2_setup, prefix2_teardown),
+fixture_with_atom_prefix_with_setup_and_teardown_calls_setup_and_teardown_test() ->
+    {foreach, Setup, Teardown, _} = hoax:fixture(?EXAMPLE_MODULE, prefix1, prefix1_setup, prefix1_teardown),
 
-    ?assertEqual(Prefix1Tests, Prefix1TestsFromString),
-    ?assertEqual(Prefix2Tests, Prefix2TestsFromString).
+    erlang:put(prefix1_setup_called, undefined),
+    erlang:put(prefix1_teardown_called, undefined),
+    Setup(),
+    Teardown(some_argument),
+
+    ?assertEqual(true, erlang:get(prefix1_setup_called)),
+    ?assertEqual({true, some_argument}, erlang:get(prefix1_teardown_called)).
+
+fixture_with_string_prefix_with_setup_and_teardown_calls_setup_and_teardown_test() ->
+    {foreach, Setup, Teardown, _} = hoax:fixture(?EXAMPLE_MODULE, "prefix2", prefix2_setup, prefix2_teardown),
+
+    erlang:put(prefix2_setup_called, undefined),
+    erlang:put(prefix2_teardown_called, undefined),
+    Setup(),
+    Teardown(some_argument),
+
+    ?assertEqual(true, erlang:get(prefix2_setup_called)),
+    ?assertEqual({true, some_argument}, erlang:get(prefix2_teardown_called)).

--- a/test/module_for_testing_fixtures.erl
+++ b/test/module_for_testing_fixtures.erl
@@ -7,17 +7,17 @@ generators_should_not_appear_in_any_fixtures_test_() -> [].
 
 neither_should_a_simple_function_test() -> ok.
 
-setup() -> ok.
-teardown(_) -> ok.
+setup() -> erlang:put(setup_called, true).
+teardown(Arg) -> erlang:put(teardown_called, {true, Arg}).
 test_function1() -> ok.
 test_function2() -> ok.
 
 prefix1_test_function_1() -> ok.
 prefix1_test_function_2() -> ok.
-prefix1_setup() -> ok.
-prefix1_teardown(_) -> ok.
+prefix1_setup() -> erlang:put(prefix1_setup_called, true).
+prefix1_teardown(Arg) -> erlang:put(prefix1_teardown_called, {true, Arg}).
 
 prefix2_test_function_1() -> ok.
 prefix2_test_function_2() -> ok.
-prefix2_setup() -> ok.
-prefix2_teardown(_) -> ok.
+prefix2_setup() -> erlang:put(prefix2_setup_called, true).
+prefix2_teardown(Arg) -> erlang:put(prefix2_teardown_called, {true, Arg}).

--- a/test/module_for_testing_fixtures.erl
+++ b/test/module_for_testing_fixtures.erl
@@ -21,3 +21,12 @@ prefix2_test_function_1() -> ok.
 prefix2_test_function_2() -> ok.
 prefix2_setup() -> erlang:put(prefix2_setup_called, true).
 prefix2_teardown(Arg) -> erlang:put(prefix2_teardown_called, {true, Arg}).
+
+parameterized_test_function1(_) -> ok.
+parameterized_test_function2(_) -> ok.
+
+prefix1_parameterized_test_function_1(_) -> ok.
+prefix1_parameterized_test_function_2(_) -> ok.
+
+prefix2_parameterized_test_function_1(_) -> ok.
+prefix2_parameterized_test_function_2(_) -> ok.


### PR DESCRIPTION
This adds hoax:parameterized_fixture/(1,2,3,4) which generate fixtures that pass data from setup into test cases as a function parameter.